### PR TITLE
Un-omit tokenized_string deleter

### DIFF
--- a/kernel/parser.c
+++ b/kernel/parser.c
@@ -2,21 +2,6 @@
 #include "../stdlib/string.h"
 #include "parser.h"
 
-/*
-// frees a `tokenized_string` struct and its subsequent member pointers
-void free_tokenized_string(struct tokenized_string *tsp) {
-    free(tsp->str);
-    free(tsp->indices);
-    free(tsp);
-}
-
-// frees the subsequent pointers of a `tokenized_string` struct
-void free_tokenized_string(struct tokenized_string tsv) {
-    free(tsv.str);
-    free(tsv.indices);
-}
-*/
-
 struct tokenized_string *tokenize_string(const char *source_str) {
     char *str = (char *)malloc(strlen(source_str) + 1, 1, NULL);
     

--- a/kernel/parser.h
+++ b/kernel/parser.h
@@ -3,26 +3,18 @@
 
 #include <stddef.h>
 
-/// This container stores a string split up by whitespace
-/// and quotation bodies.
+// this container stores a string split up by whitespace and quotation bodies
 struct tokenized_string {
-    /// Points to the internal tokenized string
-    char* str;
-    /// Points to an array of `size` `char *`s, all of which
-    /// point to the beginning of each subsequent token.
-    char** indices;
-    /// The size index of the indices array (the byte size
-    /// is calculated as `size * sizeof *indices).
-    size_t size;
+    char* str; // points to the internal tokenized string
+    char** indices; // Points to an array of `size` `char *`s, all of which point to the beginning of each subsequent token
+    size_t size; // the size index of the indices array (the byte size is calculated as `size * sizeof *indices`)
 };
 
-/// Frees a `tokenized_string` struct and its subsequent member pointers
+/// frees a `tokenized_string` struct and its subsequent member pointers
 void free_tokenized_string(struct tokenized_string *tsp);
 
-/// Instantiates a `tokenized_string` with the string passed to it.
-///
-/// `source_str` - a RHS string that whose copy is assigned as the internal
-/// `str` member of the corresponding `tokenized_string`.
+/// instantiates a `tokenized_string` with the string passed to it
+/// `source_str` is a RHS string that whose copy is assigned as the internal `str` member of the corresponding `tokenized_string`
 struct tokenized_string *tokenize_string(const char *source_str);
 
 #endif

--- a/kernel/parser.h
+++ b/kernel/parser.h
@@ -4,29 +4,25 @@
 #include <stddef.h>
 
 /// This container stores a string split up by whitespace
-/// and quotation canaries in order to tokenize the
-/// internal string by allowing it to be treated
-/// as multiple smaller strings by virtue of the
-/// indices provided by the struct.
-///
-/// The `str` member contains the internal string, and
-/// the `indices` member points to an array of `char *`
-/// which point to each token within the internal `str`.
-/// The size attribute describes the size of the array
-/// pointer to by `indices`.
+/// and quotation bodies.
 struct tokenized_string {
+    /// Points to the internal tokenized string
     char* str;
+    /// Points to an array of `size` `char *`s, all of which
+    /// point to the beginning of each subsequent token.
     char** indices;
+    /// The size index of the indices array (the byte size
+    /// is calculated as `size * sizeof *indices).
     size_t size;
 };
 
-/// frees a `tokenized_string` struct and its subsequent member pointers
+/// Frees a `tokenized_string` struct and its subsequent member pointers
 void free_tokenized_string(struct tokenized_string *tsp);
 
 /// Instantiates a `tokenized_string` with the string passed to it.
-/// The string passed to this factory function is a RHS string that
-/// is copied within the function. The `str` member of `tokenized_string`
-/// is the copied string.
+///
+/// `source_str` - a RHS string that whose copy is assigned as the internal
+/// `str` member of the corresponding `tokenized_string`.
 struct tokenized_string *tokenize_string(const char *source_str);
 
 #endif

--- a/kernel/parser.h
+++ b/kernel/parser.h
@@ -3,17 +3,30 @@
 
 #include <stddef.h>
 
+/// This container stores a string split up by whitespace
+/// and quotation canaries in order to tokenize the
+/// internal string by allowing it to be treated
+/// as multiple smaller strings by virtue of the
+/// indices provided by the struct.
+///
+/// The `str` member contains the internal string, and
+/// the `indices` member points to an array of `char *`
+/// which point to each token within the internal `str`.
+/// The size attribute describes the size of the array
+/// pointer to by `indices`.
 struct tokenized_string {
     char* str;
     char** indices;
     size_t size;
 };
 
-/*
+/// frees a `tokenized_string` struct and its subsequent member pointers
 void free_tokenized_string(struct tokenized_string *tsp);
-void free_tokenized_string(struct tokenized_string tsv);
-*/
 
+/// Instantiates a `tokenized_string` with the string passed to it.
+/// The string passed to this factory function is a RHS string that
+/// is copied within the function. The `str` member of `tokenized_string`
+/// is the copied string.
 struct tokenized_string *tokenize_string(const char *source_str);
 
 #endif


### PR DESCRIPTION
The tokenized_string struct pointer deleter will be left un-omitted, and the stack value overload of the corresponding function will be omitted entirely. Also added documentation to the respective functions and struct.